### PR TITLE
Ajuste Para Que Sejam Utilizados Somente Os Dados De Conexão De Banco Definidos Pelo Usuário

### DIFF
--- a/sloth/test/selenium/__init__.py
+++ b/sloth/test/selenium/__init__.py
@@ -255,11 +255,11 @@ class SeleniumTestCase(LiveServerTestCase):
         
         dbparams = ''
         if (dbuser):
-            dbparams += f' -U {dbuser}'
+            dbparams += ' -U {}'.format(dbuser)
         if (dbhost):
-            dbparams += f' -h {dbhost}'
+            dbparams += ' -h {}'.format(dbhost)
         if (dbport):
-            dbparams += f' -p {dbport}'
+            dbparams += ' -p {}'.format(dbport)
 
         return dbparams
 

--- a/sloth/test/selenium/__init__.py
+++ b/sloth/test/selenium/__init__.py
@@ -249,11 +249,19 @@ class SeleniumTestCase(LiveServerTestCase):
         cls.browser.service.stop()
 
     def postgres_parameters(self):
-        dbhost = settings.DATABASES['default']['HOST']
         dbuser = settings.DATABASES['default']['USER']
         dbport = settings.DATABASES['default']['PORT']
-        dbparam = '-U {} -h {} -p {}'.format(dbuser, dbhost, dbport)
-        return dbparam
+        dbhost = settings.DATABASES['default']['HOST']
+        
+        dbparams = ''
+        if (dbuser):
+            dbparams += f' -U {dbuser}'
+        if (dbhost):
+            dbparams += f' -h {dbhost}'
+        if (dbport):
+            dbparams += f' -p {dbport}'
+
+        return dbparams
 
     def create_dev_database(self, fname=None):
         dbname = settings.DATABASES['default']['NAME']


### PR DESCRIPTION
responsável: @misaelbarreto  
descrição:  
* Ajuste para que sejam utilizados somente os dados de conexão de banco definidos pelo usuário durante a execução dos testes. Ex: Caso ele não tenha passado o parâmetro "host", não usaremos esse parâmetro, permitindo assim conexão local via socket;